### PR TITLE
Fix asymetric FluidVolume packet buffer calls.

### DIFF
--- a/src/main/java/slimeknights/mantle/recipe/FluidIngredient.java
+++ b/src/main/java/slimeknights/mantle/recipe/FluidIngredient.java
@@ -90,8 +90,7 @@ public abstract class FluidIngredient {
     Collection<FluidVolume> fluids = getAllFluids();
     buffer.writeInt(fluids.size());
     for (FluidVolume stack : fluids) {
-      stack.fluidKey.toMcBuffer(buffer);
-      stack.amount().toMcBuffer(buffer);
+      stack.toMcBuffer(buffer);
     }
   }
 


### PR DESCRIPTION
Since you use the single method to read on line 223, but don't during write for some reason

Read:
https://github.com/DimensionalDevelopment/Mantle/blob/ef15db2c32f8ac8c060980b6416c2c87c60e26cf/src/main/java/slimeknights/mantle/recipe/FluidIngredient.java#L218-L227

Write:
https://github.com/DimensionalDevelopment/Mantle/blob/ef15db2c32f8ac8c060980b6416c2c87c60e26cf/src/main/java/slimeknights/mantle/recipe/FluidIngredient.java#L85-L96

(Also this would crash if the FluidVolume read custom stuff, or had properties that needed to be read).